### PR TITLE
Bug fix where if multiple usernames are found, the test_set_username function would fail. 

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -140,7 +140,7 @@ class TestDatabase(unittest.TestCase):
         database.set_username(new_user.id, new_user.username)
 
         # Checking if database updated
-        db_user_2 = database.get_user_class_by_username(new_user.username)
+        db_user_2 = database.get_user_class_by_id(new_user.id)
 
         self.assertTrue (db_user_2.as_dict() == new_user.as_dict())
 


### PR DESCRIPTION
- Fixing bug where if there were multiple elijah's the test would do a `get_user_class_by_username` and return the wrong elijah. 
    - Replaced `get_user_class_by_username` to `get_user_class_by_id` since we previously had the id. 
- In the future we will have to make sure that the username was not taken.
- I created a Issue (#76) and I will be fixing `add_user` to throw an exception if a username was found. 