### PR TITLE
Removed .container class

### DIFF
--- a/vitality/static/css/base.css
+++ b/vitality/static/css/base.css
@@ -1,6 +1,6 @@
 body {
     font-family: 'Raleway', sans-serif;
-    font-size: larger;
+    font-size: 1.5em;
 }
 
 button {
@@ -10,21 +10,20 @@ button {
 }
 
 button:hover {
-    color: #3f6499; 
+    color: #3f6499;
     text-decoration: none;
 }
 
 .button_title {
     color: white;
     background-color: none;
-    border: 1px solid white; 
+    border: 1px solid white;
     padding: 2px 10px;
-    margin: 2px;  
-    font-size: larger;
+    margin: 2px;
 }
 
 .button_title:hover {
-    color: #3f6499; 
+    color: #3f6499;
     text-decoration: none;
 }
 
@@ -44,8 +43,8 @@ button:hover {
 
 .navbar-toggler {
     background-color: #47525E;
-    
 }
+
 .navbar-toggler-icon {
     background-image: url("/static/images/bars.svg");
     fill: white;
@@ -61,4 +60,9 @@ button:hover {
 
 .navbar li a:hover {
     color: #F95F62;
+}
+
+#content {
+    width: 90%;
+    margin: auto;
 }

--- a/vitality/templates/base.html
+++ b/vitality/templates/base.html
@@ -16,20 +16,20 @@
 </head>
 
 <body>
-    <div class="container" id="whileLoading">
+    <div id="loading">
         <div class="d-flex justify-content-center align-items-center min-vh-100">
             <div class="spinner-border text-success" style="width: 100px; height: 100px;"></div>
         </div>
     </div>
-    <div class="container" style="display: none;" id="loading">
+    <div style="display: none;" id="content">
         {% include "navbar.html" ignore missing %}
 
         {% block content %}{% endblock %}
     </div>
     <script>
         window.onload = function () {
-            $("#whileLoading").hide();
-            $("#loading").show();
+            $("#loading").hide();
+            $("#content").show();
         }
     </script>
 </body>


### PR DESCRIPTION
Easier flexibility of page width and margin than .container class.

- Removed .container since it is not needed. 
- Instead using #content with a width percentage.
- Scaled text size larger for easier readability

Closes #178 